### PR TITLE
Duplicate "Time" in the rawtransaction rpc

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -196,7 +196,6 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
             if (pindex->IsInMainChain())
             {
                 entry.push_back(Pair("confirmations", 1 + nBestHeight - pindex->nHeight));
-                entry.push_back(Pair("time", (int64_t)pindex->nTime));
                 entry.push_back(Pair("blocktime", (int64_t)pindex->nTime));
             }
             else


### PR DESCRIPTION
When the iquidus explorer try an update show the error `message: 'Duplicate key "time"'` . The solution was discussed on the [iquidus issue 335](https://github.com/iquidus/explorer/issues/335).